### PR TITLE
既読機能インターフェイス見直し

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,7 @@
 class PostsController < ApplicationController
+  # Token検証を無効にする場合付ける
+  # protect_from_forgery
+
   def index
     @posts = Post.all.order(id: "DESC")
   end
@@ -8,6 +11,7 @@ class PostsController < ApplicationController
   # end
 
   def create
+    # binding.pry
     post = Post.create(content: params[:content], checked: false)
     # redirect_to action: :index
     render json:{ post: post }

--- a/app/javascript/checked.js
+++ b/app/javascript/checked.js
@@ -9,17 +9,21 @@ function check(){
 
     post.addEventListener("click", () => {
       const postId = post.getAttribute("data-id");
+      const csrfToken = document.getElementsByName("csrf-token")[0].content;
+      const crsfTokenJSON = JSON.stringify({"authenticity_token": csrfToken});
       // debugger
       const XHR = new XMLHttpRequest();
-      XHR.open("GET", `/posts/${postId}`, true);
+      XHR.open("PATCH", `/posts/${postId}`, true);
+      XHR.setRequestHeader("Content-Type", "application/json");
       XHR.responseType = "json";
-      XHR.send();
+      XHR.send(crsfTokenJSON);
       XHR.onload = () => {
         if(XHR.status != 200){
           alert(`Error ${XHR.status}: ${XHR.statusText}`);
           return null;
         }
         const item = XHR.response.post;
+        // debugger
         if(item.checked === true){
           post.setAttribute("data-check", "true");
         }else if(item.checked === false ){

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,5 @@ Rails.application.routes.draw do
   root to: 'posts#index'
   # get 'posts/new', to: 'posts#new'
   post 'posts', to: 'posts#create'
-  get 'posts/:id', to: 'posts#checked'
+  patch 'posts/:id', to: 'posts#checked'
 end


### PR DESCRIPTION
# What
既読機能のクラサバインターフェイス見直しとして以下を修正。
- routers
GETメソッド → PATCHメソッド
- javascript
  - GETメソッド → PATCHメソッド
  - 上記メソッド変更に伴い、CSRF対策トークンの取得・送付処理追加
- controller
コメントのみ。（CSRF対策のトークン無効化処理をコメントアウト）

# Why
GETメソッドで更新はRESTfulな実装でないため。
